### PR TITLE
Bug1239263 Added hubot-authentication in order to restrict access for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,8 @@ Add the subdomain hubot should connect to. If you web URL looks like
 
 You may want to get comfortable with `heroku logs` and `heroku restart` if
 you're having issues.
+
+### Authentication
+
+Assign roles to users and restrict command access in other scripts.
+More details https://github.com/hubot-scripts/hubot-auth

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,5 +2,6 @@
   "hubot-heroku-keepalive",
   "hubot-redis-brain",
   "hubot-sns",
-  "hubot-mute"
+  "hubot-mute",
+  "hubot-auth"
 ]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "hubot-scripts": "^2.5.16",
     "hubot-sns": "^0.2.1",
     "moment-timezone": "~0.3",
-    "hubot-mute": "^0.0.5"
+    "hubot-mute": "^0.0.5",
+    "hubot-auth": "^1.2.0"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Set the HUBOT_AUTH_ADMIN environment variable to a comma separated list of user IDs who should have admin privileges. Getting user IDs is quite simple using the redis-cli command.

I tested with nicknames and worked also.

I tested locally the changes for external-scripts.json and  package.json and worked without any issue
